### PR TITLE
Document Pyodide compatibility marker convention

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,10 @@ dependencies = [
     "pathsim>0.13",
     "numpy>=1.15",
     "scipy>=1.2",
+    # If a dependency ships native code that can't be installed in Pyodide,
+    # tag it with `; sys_platform != 'emscripten'` so a normal pip install
+    # still pulls it eagerly but micropip in the browser skips it. Pair
+    # this with a defensive re-export in `pathsim_chem/__init__.py`.
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Add a comment to `pyproject.toml` explaining how to gate native-code deps behind a `sys_platform != 'emscripten'` marker so they're skipped under Pyodide while a normal pip install still pulls them eagerly. No functional change — chem has no heavy deps today.