### PR TITLE
Require pathsim>=0.23 for BVP1D

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,8 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-    "pathsim>0.13",
+    # GLC block uses pathsim.blocks.BVP1D, introduced in pathsim 0.23
+    "pathsim>=0.23",
     "numpy>=1.15",
     "scipy>=1.2",
     # If a dependency ships native code that can't be installed in Pyodide,


### PR DESCRIPTION
The GLC block imports `pathsim.blocks.BVP1D` (module level), which exists since pathsim 0.23. The declared `pathsim>0.13` allowed installs against older pathsim where `import pathsim_chem` fails entirely — this is what broke all chem blocks in pathview (pathsim/pathview#318).

Verified: `import pathsim_chem` succeeds against pathsim 0.23.0.